### PR TITLE
Changes needed for adding Org to repo name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@ Introduction
     :alt: Discord
 
 
-.. image:: https://github.com/circuitpython/CircuitPython_DisplayIO_Cartesian/workflows/Build%20CI/badge.svg
-    :target: https://github.com/circuitpython/CircuitPython_DisplayIO_Cartesian/actions
+.. image:: https://github.com/circuitpython/CircuitPython_Org_DisplayIO_Cartesian/workflows/Build%20CI/badge.svg
+    :target: https://github.com/circuitpython/CircuitPython_Org_DisplayIO_Cartesian/actions
     :alt: Build Status
 
 
@@ -73,7 +73,7 @@ Contributing
 ============
 
 Contributions are welcome! Please read our `Code of Conduct
-<https://github.com/circuitpython/CircuitPython_DisplayIO_Cartesian/blob/HEAD/CODE_OF_CONDUCT.md>`_
+<https://github.com/circuitpython/CircuitPython_Org_DisplayIO_Cartesian/blob/HEAD/CODE_OF_CONDUCT.md>`_
 before contributing to help this project stay welcoming.
 
 Documentation


### PR DESCRIPTION
This adds "Org" to the repo URLs in the readme file. Both for workflow badge, and code of conduct link.

The repo name should be changed to `CircuitPython_Org_DisplayIO_Cartesian` at the same time that this PR  is merged.