### PR TITLE
add Org to pypi repo URL in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/x-rst",
     # The project's main homepage.
-    url="https://github.com/circuitpython/CircuitPython_DisplayIO_Cartesian.git",
+    url="https://github.com/circuitpython/CircuitPython_Org_DisplayIO_Cartesian.git",
     # Author details
     author="Jose David M.",
     author_email="",


### PR DESCRIPTION
Accidentally forgot to check this file when I made #2 

This adds one additional change inside setup.py to update to the correct URL with Org in it.