### PR TITLE
Remove max_size parameter

### DIFF
--- a/displayio_cartesian.py
+++ b/displayio_cartesian.py
@@ -102,7 +102,7 @@ class Cartesian(Widget):
     .. code-block:: python
 
         my_plane= Plane(20, 30) # instance the plane at x=20, y=30
-        my_group = displayio.Group(max_size=10) # make a group that can hold 10 items
+        my_group = displayio.Group() # make a group
         my_group.append(my_plane) # Add my_plane to the group
 
         #
@@ -183,7 +183,7 @@ class Cartesian(Widget):
         **kwargs,
     ) -> None:
 
-        super().__init__(**kwargs, max_size=3)
+        super().__init__(**kwargs)
 
         self._background_color = background_color
 

--- a/examples/displayio_cartesian_advanced_test.py
+++ b/examples/displayio_cartesian_advanced_test.py
@@ -21,7 +21,7 @@ display = board.DISPLAY  # create the display on the PyPortal or Clue (for examp
 
 
 # Create different Cartesian widgets
-my_group = displayio.Group(max_size=10)
+my_group = displayio.Group()
 
 car = Cartesian(
     x=25,

--- a/examples/displayio_cartesian_simpletest.py
+++ b/examples/displayio_cartesian_simpletest.py
@@ -35,7 +35,7 @@ my_plane = Cartesian(
     font_color=0xFFFFFF,  # ticks line color
 )
 
-my_group = displayio.Group(max_size=3)
+my_group = displayio.Group()
 my_group.append(my_plane)
 display.show(my_group)  # add high level Group to the display
 


### PR DESCRIPTION
Remove the `max_size` parameter. It is no longer used by `displayio.Group`
Ref: adafruit/circuitpython#4959

Tested on a Pynt:
```
Adafruit CircuitPython 6.3.0 on 2021-06-01; Adafruit PyPortal with samd51j20
```